### PR TITLE
Add Ample Geyser Proxy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more info about the Geyser interface: https://docs.solana.com/developing/plu
 
 ## Geyser Related
 
- * [Ample Geyser Proxy](https://github.com/ample-sh/ample_geyser_gateway): Stream geyser notifications via QUIC to a gateway client that can load any geyser plugin. Think nginx for geyser.
+ * [Ample Geyser Proxy](https://github.com/ample-sh/ample_geyser_gateway): Stream Solana validator events over QUIC/TLS to run Geyser plugins remotely — keeping your validator lean. Running solana v3.x.x
  * [Solana Postgres RPC server](https://github.com/lijunwangs/solana-postgres-rpc-server): A server to respond to RPC requests via Postgres data written by the Postgres plugin.
  * [gRPC connector](https://github.com/ckamm/solana-accountsdb-connector/tree/master/connector-mango): A connector that connects to gRPC plugin to parse data received.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For more info about the Geyser interface: https://docs.solana.com/developing/plu
 
 ## Geyser Related
 
+ * [Ample Geyser Proxy](https://github.com/ample-sh/ample_geyser_gateway): Stream geyser notifications via QUIC to a gateway client that can load any geyser plugin. Think nginx for geyser.
  * [Solana Postgres RPC server](https://github.com/lijunwangs/solana-postgres-rpc-server): A server to respond to RPC requests via Postgres data written by the Postgres plugin.
  * [gRPC connector](https://github.com/ckamm/solana-accountsdb-connector/tree/master/connector-mango): A connector that connects to gRPC plugin to parse data received.
 


### PR DESCRIPTION
taken from the ample README:

```The validator hosts a tiny proxy that streams events over QUIC/TLS, and your gateway picks them up and runs the plugins locally.```

essentially is a reverse proxy for geyser plugins